### PR TITLE
Safer code using sequence functions

### DIFF
--- a/R/Gibbs_lcm.R
+++ b/R/Gibbs_lcm.R
@@ -60,7 +60,7 @@ sample_leaf_locations_pg <- function(item_membership_list, dist_mat_old,
   J <- length(unlist(item_membership_list))
   # cumulative index of item groups
   new_leaf_data <- matrix(NA, nrow = K, ncol = J)
-  for (g in 1:length(item_membership_list)) {
+  for (g in seq_along(item_membership_list)) {
     J_g <- length(item_membership_list[[g]])
     precision_mat <- crossprod(dist_mat_old$Dhalf_Ut) / Sigma_by_group[g]
     # extract indices

--- a/R/ddtlcm_fit.R
+++ b/R/ddtlcm_fit.R
@@ -235,7 +235,7 @@ ddtlcm_fit <- function(K, data, item_membership_list, total_iters = 5000,
       dist_mat_old <- sampled_tree$dist_mat
       # to save memory, we only update the tree list if the proposal is accepted; otherwise
       # create a pointer to the old object
-      if (sampled_tree$accept | iter == 1) {
+      if (sampled_tree$accept || iter == 1) {
         tree_list[[iter]] <- sampled_tree$tree_phylo4d
         dist_mat_list[[iter]] <- sampled_tree$dist_mat
         tree_phylo4d_old <- sampled_tree$tree_phylo4d

--- a/R/initialization.R
+++ b/R/initialization.R
@@ -14,7 +14,7 @@ initialize_poLCA <- function(K, data, ...){
   # model <- poLCA(fm, data.frame(data+1), nclass=K, maxiter=100,
   #                tol=1e-5, na.rm=FALSE, nrep=10, verbose=FALSE, calc.se=TRUE)
   response_prob_simple_lcm <- matrix(0, nrow = K, ncol = ncol(data))
-  for (j in 1:ncol(data)) {
+  for (j in seq_len(ncol(data))) {
     response_prob_simple_lcm[,j] <- model$probs[[variable_names[j]]][,2]
   }
   colnames(response_prob_simple_lcm) <- variable_names
@@ -220,7 +220,7 @@ initialize <- function(K, data, item_membership_list, c=1, c_order=1,
     # need to add rows corresponding to internal nodes
     tree_data <- rbind(tree_data, matrix(NA, nrow = K-1, ncol = ncol(tree_data)))
     rownames(tree_data) <- c(paste0("v", 1:K), paste0("u", 1:K))
-    colnames(tree_data) <- c(paste0("x", 1:ncol(tree_data)))
+    colnames(tree_data) <- c(paste0("x", seq_len(ncol(tree_data))))
     initial_tree_hclust <- addData(initial_tree_hclust, all.data = tree_data )
     init_info <- logllk_ddt(1, c_order, Sigma_by_group = rep(1, G), tree_phylo4d=initial_tree_hclust,
                             item_membership_list,
@@ -242,7 +242,7 @@ initialize <- function(K, data, item_membership_list, c=1, c_order=1,
     # need to add rows corresponding to internal nodes
     tree_data <- rbind(tree_data, matrix(NA, nrow = K-1, ncol = ncol(tree_data)))
     rownames(tree_data) <- c(paste0("v", 1:K), paste0("u", 1:K))
-    colnames(tree_data) <- c(paste0("x", 1:ncol(tree_data)))
+    colnames(tree_data) <- c(paste0("x", seq_len(ncol(tree_data))))
     tree_phylo4d <- addData(initial_tree_hclust, all.data = tree_data )
   }
   

--- a/R/loglikehoods.R
+++ b/R/loglikehoods.R
@@ -55,7 +55,7 @@ logllk_location <- function(tree_phylo4d, Sigma_by_group, item_membership_list, 
       names(branch_lengths) <- ancestors_internal
 
       # compute row variance of the matrix normal distribution of leaf nodes
-      row_var_by_group <- unlist(t(sapply(1:length(pa_ancestors_internal),
+      row_var_by_group <- unlist(t(sapply(seq_along(pa_ancestors_internal),
                                           function(x) branch_lengths[x])))
       # row_var_by_group <- colSums(matrix(row_var_by_group, ncol = G))
       row_var_by_group <- sum(row_var_by_group)

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -179,7 +179,7 @@ plot_tree_with_barplot <- function(tree_with_parameter, response_prob, item_memb
   } else{
     class_label <- paste0("Class ", 1:K)
   }
-  if (!(is.null(class_probability_lower) & is.null(class_probability_higher))){
+  if (!(is.null(class_probability_lower) && is.null(class_probability_higher))){
     class_label <- paste0(class_label, 
                           " (", round(class_probability_lower, 2), ", ", round(class_probability_higher, 2), ")")
   }

--- a/R/simulate_DDT_functions.R
+++ b/R/simulate_DDT_functions.R
@@ -217,10 +217,10 @@ simulate_parameter_on_tree <- function(tree_phylo, Sigma_by_group, item_membersh
   
   while( length(start_node)!=0 ){
     next_from_nonTip <- numeric()
-    for (cur_from_idx in 1:length(start_node)){
+    for (cur_from_idx in seq_along(start_node)){
       from_node <- start_node[cur_from_idx]
       to_nodes <- descendants(tr_phylo4, node=names(from_node), type="children")
-      for (i in 1:length(to_nodes)) {
+      for (i in seq_along(to_nodes)) {
         to_node = to_nodes[i]
         edge_len <- edgeLength(tr_phylo4)[getEdge(tr_phylo4, node=names(to_node), type="descendant")]
         


### PR DESCRIPTION
- Converted `1:length(x)` code to `seq_along(x)`
- Converted `1:x` code to `seq_len(x)`
- Using `&&` and `||` in if statements since if statements are scalar conditionals

The sequence functions will behave adequately in `1:x` when `x` is 0.

https://github.com/openjournals/joss-reviews/issues/6220